### PR TITLE
feat(api): add attention checker for every 10th question

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,6 @@
   - [ ] What problem this PR is solving.
   - [ ] How this problem was solved.
   - [ ] How reviewers can test my changes.
-- [ ] I've indicated what Jira issue(s) this PR is linked to.
 - [ ] I've included tests I've run to ensure my changes work.
 - [ ] I've added unit tests for any new code, if applicable.
 - [ ] I've documented any added code.

--- a/src/configration/controller/answer_config_controller.py
+++ b/src/configration/controller/answer_config_controller.py
@@ -2,35 +2,80 @@ from flask import Blueprint, jsonify, request
 
 from src import db
 from src.common.model.ApiResponse import ApiResponse
-from src.configration.repository.answer_config_repository import \
-    AnswerConfigurationRepository
-from src.configration.service.answer_config_service import \
-    AnswerConfigurationService
+from src.configration.repository.answer_config_repository import (
+    AnswerConfigurationRepository,
+)
+from src.configration.service.answer_config_service import AnswerConfigurationService
+from src.answer.repository.answer_repository import AnswerRepository
+from src.user.utils.auth_utils import (
+    jwt_validation_required,
+    get_user_email_from_jwt,
+)
 
 admin_answer_config_blueprint = Blueprint("admin_answer_config", __name__)
 answer_config_blueprint = Blueprint("answer_config", __name__)
 
-answer_repository = AnswerConfigurationRepository(db.session)
-answer_service = AnswerConfigurationService(answer_repository)
+_cfg_repo = AnswerConfigurationRepository(db.session)
+_cfg_service = AnswerConfigurationService(_cfg_repo)
+
+
+def _needs_attention_check(user_email: str, repo: AnswerRepository) -> bool:
+    """
+    Check if the user needs an attention check based on their answered cases.
+    Only applies if the user has answered a multiple of 10 cases.
+    This is a simple heuristic to ensure users are paying attention.
+
+    :param user_email: The email of the user to check.
+    :param repo: The AnswerRepository instance to query answered cases.
+    :return: bool: True if the user needs an attention check, False otherwise.
+    """
+    completed: list[int] = repo.get_answered_case_list_by_user(user_email)
+    return (len(completed) + 1) % 10 == 0  # upcoming case index
 
 
 @admin_answer_config_blueprint.route("/config/answer", methods=["POST"])
 def add_answer_config():
+    """
+    Endpoint to add a new answer configuration.
+    This is intended for administrative use only.
+
+    :return: Tuple containing a JSON response with the new configuration ID and HTTP status code.
+    """
     body = request.get_json()
-
-    id = answer_service.add_new_answer_config(body)
-
-    return (
-        jsonify(ApiResponse.success({"id": id})),
-        200,
-    )
+    new_id = _cfg_service.add_new_answer_config(body)
+    return jsonify(ApiResponse.success({"id": new_id})), 200
 
 
 @answer_config_blueprint.route("/config/answer", methods=["GET"])
+@jwt_validation_required()
 def get_latest_answer_config():
-    answer_config = answer_service.get_latest_answer_config().to_dict()
+    """
+    Endpoint to retrieve the latest answer configuration.
+    For the 10th, 20th, 30th, etc. answered cases, an attention check is added dynamically.
+    This is to ensure users are paying attention to their assignments.
 
-    return (
-        jsonify(ApiResponse.success(answer_config)),
-        200,
-    )
+    :return: Tuple containing a JSON response with the latest answer configuration and HTTP status code.
+    """
+    user_email = get_user_email_from_jwt()
+    cfg_dict = _cfg_service.get_latest_answer_config().to_dict()
+
+    # dynamic injection of attention check
+    repo = AnswerRepository(db.session)
+    if _needs_attention_check(user_email, repo):
+        attention_cfg = {
+            "title": (
+                "Attention Check – please read carefully and select "
+                "'All of the above' below"
+            ),
+            "type": "SingleChoice",
+            "options": [
+                "I wasn’t really reading",
+                "I’m just clicking through",
+                "I prefer not to answer",
+                "All of the above",  # <- correct answer
+            ],
+            "required": "true",
+        }
+        cfg_dict["config"] = list(cfg_dict["config"]) + [attention_cfg]
+
+    return jsonify(ApiResponse.success(cfg_dict)), 200


### PR DESCRIPTION
## SUMMARY

This PR adds an attention checker question for every 10th question so we can ensure users are paying close attention to their tasks, by dynamically injecting this question on every 10th question (e.g. 10th, 20th, 30th, etc.)

## TEST PLAN

1. Sign up for an account and go to the cases page.
2. Repeatedly answer the first 9 questions. Confirm that you're now at the 10th question.
3. Scroll all the way to the bottom on the questions page, and verify that there is an extra attention checker question.
4. Make sure you can submit the answers for the 10th case normally.

---

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving.
  - [X] How this problem was solved.
  - [X] How reviewers can test my changes.
- [X] I've included tests I've run to ensure my changes work.
- [ ] I've added unit tests for any new code, if applicable.
- [X] I've documented any added code.
