### PR TITLE
fix: remove PHYSICAL EXAMINATION section when empty after filtering

### DIFF
--- a/src/cases/service/case_service.py
+++ b/src/cases/service/case_service.py
@@ -427,19 +427,11 @@ class CaseService:
             
             top.values = filtered_children
 
-        # --- 4e) Remove empty PHYSICAL EXAMINATION section entirely ---
-        # After filtering/gating, if no children remain under PHYSICAL EXAMINATION, drop the section.
-        pruned_case_details: list[TreeNode] = []
-        for section in case_details:
-            if section.key == "PHYSICAL EXAMINATION":
-                # Remove any empty child nodes first
-                if isinstance(section.values, list):
-                    section.values = [c for c in section.values if getattr(c, "values", None)]
-                if not section.values:
-                    # Skip adding this section entirely
-                    continue
-            pruned_case_details.append(section)
-        case_details = pruned_case_details
+        # --- 4c) Remove PHYSICAL EXAMINATION section if empty after filtering ---
+        case_details = [
+            section for section in case_details
+            if not (section.key == "PHYSICAL EXAMINATION" and not section.values)
+        ]
 
         # sort and wrap into TreeNodes
         important_infos.sort(key=itemgetter("weight"))


### PR DESCRIPTION
After filtering out BMI and other measurements, if the PHYSICAL EXAMINATION section has no children left, remove it entirely from the case details.

